### PR TITLE
Update README.md instructions that actually build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,92 @@
-# OctopusNet
+# OctopusNet Buildroot
 
 
-###Prepare for Building
-On Debian/Ubuntu (as root or using sudo):
-
-```
- >apt-get install build-essential bison flex gettext libncurses5-dev texinfo autoconf automake libtool
- >apt-get install libpng12-dev libglib2.0-dev libgtk2.0-dev gperf libxt-dev libxp-dev
- >apt-get install rsync git subversion mercurial
-```
-
-* Ensure bash ist default shell (Debian/Ubuntu standard is dash):
+### Prepare
+For building on Debian/Ubuntu run the following commands(remove sudo if already root user):
 
 ```
-  >dpkg-reconfigure dash
+sudo apt-get -y install build-essential bison flex gettext libncurses5-dev texinfo autoconf automake libtool \
+libpng12-dev libglib2.0-dev libgtk2.0-dev gperf libxt-dev rsync git subversion mercurial bc \
+#libxp-dev missing in Debian9/Ubuntu16.04
 ```
-  and select no.
-
-* Clone the octonet and ddvb repositories:
-
+* Check if 'bash' is the default shell (Debian/Ubuntu standard is dash)?
 ```
-  >git clone -b master https://github.com/DigitalDevices/octonet.git octonet
-  >git clone -b master https://github.com/DigitalDevices/dddvb.git dddvb
-  >cd octonet  
-  >./mk.patch
+echo $0
+#or
+echo $SHELL
 ```
-If needed replace branch (master) and repository path with your own.
-
-###Building
-
-Complete build (needed once)
+* If output is "-dash" instead of "-bash" run following command and select "no"!
 ```
-  >./mk.all
+sudo dpkg-reconfigure dash
 ```
 
-Rebuild main firmware
-```
-  >./mk
-```
-
-###Installing
-
-* Create a subdirectory octonet on a local webserver, enable directory listing.
+Clone the "octonet" and "dddvb" repositories and reset both to a certain commit that actually builds:
 
 ```
-  >cp buildroot/output-octonet/images/octonet.* <your webserver root>/octonet
+git clone -b master https://github.com/DigitalDevices/dddvb.git dddvb
+cd dddvb
+git reset --hard 933779a
+#git show #check if current commit is indeed 933779a press 'q' to exit
+cd ..
+
+git clone -b master https://github.com/DigitalDevices/octonet.git octonet
+cd octonet
+git reset --hard cd19e9e
+#git show #check if current commit is indeed cd19e9e
+./mk.patch
+```
+* Fix Buildroot broken url for i2c-tools!
+```
+sed -i "s|http://dl.lm-sensors.org/i2c-tools/releases|http://oe-lite.org/mirror/i2c-tools|" buildroot/package/i2c-tools/i2c-tools.mk
 ```
 
-On some servers a .htaccess file with:
-```
-Options +Indexes
-```
-in the octonet directory might be necessary.
+### Building
+Run the following command for a complete build (needed once):
 
-* Configure your OctopusNet(s) to use your webserver as update server:
+```
+./mk.all
+```
+* For rebuilding main firmware just run:
+```
+./mk
+```
+
+When building succeeds (after ~20 minutes on a old i7quadcore) the size of the default custom firmware image will be ~5.7MB big and can be found in:
+
+```
+ls -la buildroot/output-octonet/images
+ls -la buildroot/output-oc
+```
+
+### Installing
+For upgrading the firmware within the OctopusNet webinterface, you must point it to a local webserver holding these (custombuild) firmware files in a subdirectory "octonet" that uses directory listing. The following commands will let you install a webserver on the very same machine your were building firmware and serve the custom firmware files.
+
+```
+sudo apt-get -y install lighttpd
+echo 'dir-listing.activate = "enable"' | sudo tee -a /etc/lighttpd/lighttpd.conf
+sudo systemctl restart lighttpd.service
+
+sudo mkdir /var/www/html/octonet
+sudo cp buildroot/output-octonet/images/octonet.* /var/www/html/octonet/
+
+hostname -I #<WebServer IP>
+```
+* Check with your webbrowser if the following URL will show a directory listing:
+```
+http://<WebServer IP>/octonet
+```
+
+Configure your OctopusNet(s) to use your buildmachine/webserver as a updateserver on the following URL:
+
 ```
 http://<OctopusNet IP>/updateserver.html
 ```
-Initiate update from the OctopusNet 
+Change the current updateserver address to ipaddress of the <WebServer IP> and Initiate update from the OctopusNet.
 
 
 Note: for security reasons only private ip addresses (10.0.0.0/8, 172.16.0.0/12, 192.168,0.0/16) are accepted
 
 
-You can find details about the OctopusNet hardware, the flash memory map and the boot process
-in dddvb/docs/octopusnet in the dddvb repo!
-
+You can find details about OctopusNet its hardware, flash memory, boot process and stock firmware: 
+* [dddvb/docs/octopusnet](https://github.com/DigitalDevices/dddvb/blob/master/docs/octopusnet)
+* [firmware archive](http://download.digital-devices.de/download/linux/octonet/)


### PR DESCRIPTION
Questions:
Dear @mvoelkel and/or @rjkm please update/bisect both repositories to the latest commit (reset --hard 933779a/cd19e9e I use as example) that actually build?

Is libxp-dev really necessary for building?

The image is around 5.7MB, according to the specs there is 256MB of flash does it mean I can safely flash a firmware that is ~12MB or maybe 200MB?

Please add a JTAG "openocd.cfg" for this target/board so a Raspberry Pi user can fix bad flash or bricked hardware by hackattack.